### PR TITLE
fix: update static content links to `cowtool-llc`

### DIFF
--- a/amplify_site/index.html
+++ b/amplify_site/index.html
@@ -189,11 +189,11 @@ CX,BKK,HKG,C</textarea>
 
 <div>
     Download <a
-        href="https://raw.githubusercontent.com/scottkennedy/ac-aqd/main/src/main/resources/country_continents.csv">
+        href="https://raw.githubusercontent.com/cowtool-llc/ac-sqd/main/src/main/resources/country_continents.csv">
     country data</a>,
-    <a href="https://raw.githubusercontent.com/scottkennedy/ac-aqd/main/src/main/resources/airports.csv">
+    <a href="https://raw.githubusercontent.com/cowtool-llc/ac-sqd/main/src/main/resources/airports.csv">
         airport data</a>,
-    <a href="https://raw.githubusercontent.com/scottkennedy/ac-aqd/main/src/main/resources/aeroplan_distances.csv">
+    <a href="https://raw.githubusercontent.com/cowtool-llc/ac-sqd/main/src/main/resources/aeroplan_distances.csv">
         Aeroplan distance data</a>
 </div>
 


### PR DESCRIPTION
The links to download the CSV data still point to the old `scottkennedy/ac-aqd` repo. While they are still accessible (for now), their data is stale and since the original repo has been moved, they will stop working eventually.