### PR TITLE
Tweak logic for detecting Aeroplan fare bases

### DIFF
--- a/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
+++ b/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
@@ -213,8 +213,8 @@ private abstract class SimplePartnerEarningCalculator(
     ) = calculate(distanceResult, fareClass, hasAeroplanStatus)
 }
 
-fun isAeroplanFareBasis(fareBasis: String) = fareBasis.contains("BP00") ||
-        fareBasis.contains("AERO")
+fun isAeroplanFareBasis(fareBasis: String) =
+    fareBasis.contains("BP00") || fareBasis.contains("AERO")
 
 private val acCalculator: EarningCalculator =
     calc@{ distanceResult, _, originCountry, _, _, destinationCountry, _, fareClass, fareBasis, _, hasAeroplanStatus, bonusPointsPercentage ->

--- a/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
+++ b/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
@@ -213,9 +213,8 @@ private abstract class SimplePartnerEarningCalculator(
     ) = calculate(distanceResult, fareClass, hasAeroplanStatus)
 }
 
-fun isAeroplanFareBasis(fareBasis: String) =
-    fareBasis.contains("BP00") ||
-            fareBasis.contains("AERO")
+fun isAeroplanFareBasis(fareBasis: String) = fareBasis.contains("BP00") ||
+        fareBasis.contains("AERO")
 
 private val acCalculator: EarningCalculator =
     calc@{ distanceResult, _, originCountry, _, _, destinationCountry, _, fareClass, fareBasis, _, hasAeroplanStatus, bonusPointsPercentage ->

--- a/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
+++ b/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
@@ -214,10 +214,8 @@ private abstract class SimplePartnerEarningCalculator(
 }
 
 fun isAeroplanFareBasis(fareBasis: String) =
-    fareBasis.endsWith("BP00") || // TODO: Remove after 2022-11-06
-            fareBasis.contains("AERO") ||
-            fareBasis.startsWith("X") ||
-            fareBasis.startsWith("I")
+    fareBasis.contains("BP00") ||
+            fareBasis.contains("AERO")
 
 private val acCalculator: EarningCalculator =
     calc@{ distanceResult, _, originCountry, _, _, destinationCountry, _, fareClass, fareBasis, _, hasAeroplanStatus, bonusPointsPercentage ->
@@ -294,6 +292,7 @@ private val acCalculator: EarningCalculator =
                         } else {
                             ACEarningResult(sqmPercent = 50, isSqmPercentEstimated = true)
                         }
+
                         else -> ACEarningResult(sqmPercent = 125, isSqmPercentEstimated = true)
                     }
                 }
@@ -318,6 +317,7 @@ private val acCalculator: EarningCalculator =
                         } else {
                             ACEarningResult(sqmPercent = 50, isSqmPercentEstimated = true)
                         }
+
                         else -> ACEarningResult(sqmPercent = 150, isSqmPercentEstimated = true)
                     }
                 }

--- a/src/test/kotlin/com/cowtool/acsqd/sqm/SqmTest.kt
+++ b/src/test/kotlin/com/cowtool/acsqd/sqm/SqmTest.kt
@@ -850,4 +850,23 @@ internal class SqmTest {
             assertEquals(true, isSqmPercentEstimated)
         }
     }
+
+    @Test
+    fun `getEarningResult() handles paid J with I-fare basis`() {
+        with(
+            getEarningResult(
+                operatingAirline = "AC",
+                marketingAirline = "AC",
+                origin = "YVR",
+                destination = "YYZ",
+                fareClass = "P",
+                fareBasis = "INX00YN0",
+                ticketNumber = "123",
+                hasAeroplanStatus = true,
+                bonusPointsPercentage = 0,
+            )!!
+        ) {
+            assertEquals(3114, sqm)
+        }
+    }
 }

--- a/src/test/kotlin/com/cowtool/acsqd/sqm/SqmTest.kt
+++ b/src/test/kotlin/com/cowtool/acsqd/sqm/SqmTest.kt
@@ -864,7 +864,7 @@ internal class SqmTest {
                 ticketNumber = "123",
                 hasAeroplanStatus = true,
                 bonusPointsPercentage = 0,
-            )!!
+            )!!,
         ) {
             assertEquals(3114, sqm)
         }


### PR DESCRIPTION
Partner redemptions still contain "BP00", but non-*A tickets might begin with X or I, and still earn SQx.