### PR TITLE
AC X/I class earns 0

### DIFF
--- a/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
+++ b/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
@@ -233,7 +233,7 @@ private val acCalculator: EarningCalculator =
         )
 
         if (!fareBasis.isNullOrEmpty()) {
-            if (isAeroplanFareBasis(fareBasis)) {
+            if (isAeroplanFareBasis(fareBasis) || fareClass in setOf("X", "I")) {
                 return@calc ACEarningResult(sqmPercent = 0, isSqmPercentEstimated = false)
             }
 

--- a/src/test/kotlin/com/cowtool/acsqd/sqm/SqmTest.kt
+++ b/src/test/kotlin/com/cowtool/acsqd/sqm/SqmTest.kt
@@ -869,4 +869,39 @@ internal class SqmTest {
             assertEquals(3114, sqm)
         }
     }
+
+    @Test
+    fun `partner issued X and I class earns 0 on AC`() {
+        with(
+            getEarningResult(
+                operatingAirline = "AC",
+                marketingAirline = "AC",
+                origin = "YVR",
+                destination = "YYZ",
+                fareClass = "X",
+                fareBasis = "RANDOM-LT",
+                ticketNumber = "016",
+                hasAeroplanStatus = true,
+                bonusPointsPercentage = 0,
+            )!!,
+        ) {
+            assertEquals(0, sqm)
+        }
+
+        with(
+            getEarningResult(
+                operatingAirline = "AC",
+                marketingAirline = "AC",
+                origin = "YVR",
+                destination = "YYZ",
+                fareClass = "I",
+                fareBasis = "RANDOM-EL",
+                ticketNumber = "016",
+                hasAeroplanStatus = true,
+                bonusPointsPercentage = 0,
+            )!!,
+        ) {
+            assertEquals(0, sqm)
+        }
+    }
 }


### PR DESCRIPTION
#402 introduced a bug where AC X/I class with a fare basis that doesn't include "AERO" or "BP00", but does end in a brand code (FL/EL etc.) would claim to earn SQx.