### PR TITLE
Update TAP earning to the June 1, 2026 table

### DIFF
--- a/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
+++ b/src/main/kotlin/com/cowtool/acsqd/sqm/Calculators.kt
@@ -943,26 +943,47 @@ private val tkCalculator = object : StarAllianceEarningCalculator() {
 }
 
 private val tpCalculator = object : StarAllianceEarningCalculator() {
+    /**
+     * TAP identifies its fare brand with a three-letter code embedded in the fare
+     * basis (e.g. Y15CLC0A), rather than the two-letter suffix Air Canada uses.
+     * Callers may instead name the brand directly (e.g. TP,ARN,LIS,O,PLUS), so
+     * accept both spellings and search rather than slice at a fixed offset.
+     *
+     * Top Prime and Top Executive earn the same as Prime and Executive, so the
+     * "Top" variants need no cases of their own.  Prime must be matched before
+     * Executive, or "TOP PRIME" would be read as business.
+     *
+     * Returns null when no brand could be identified.
+     */
+    private fun getBrandPercentMultiplier(args: CalculatorArgs): Int? {
+        val brand = args.fareBasis?.split("/")?.first()?.uppercase()
+
+        if (brand.isNullOrBlank()) {
+            return null
+        }
+
+        return when {
+            "DSC" in brand || "DISCOUNT" in brand -> 0
+            "BSC" in brand || "BASIC" in brand -> 50
+            "CLC" in brand || "CLASSIC" in brand -> 100
+            "PLU" in brand -> 100
+            "PRIME" in brand -> 115
+            "TOP" in brand || "EXE" in brand -> 150
+            else -> null
+        }
+    }
+
     override fun getDistancePercentMultiplier(args: CalculatorArgs): Int {
-        val specialDestinations = setOf("LIS", "OPO", "PXO", "FNC")
-        return if (args.origin in specialDestinations && args.destination in specialDestinations) {
-            when (args.fareClass) {
-                "C", "D", "Z", "J" -> 150
-                "Y", "B" -> 100
-                "M", "H", "Q", "W", "K", "U" -> 100
-                "V", "S", "L", "A", "G", "P" -> 50
-                "O", "E", "T" -> 0
-                else -> 0
-            }
-        } else {
-            when (args.fareClass) {
-                "C", "D", "Z", "J" -> 150
-                "Y", "B" -> 100
-                "M", "H", "Q" -> 100
-                "V", "W", "S", "L", "K", "U", "A", "G", "P" -> 50
-                "O", "E", "T" -> 0
-                else -> 0
-            }
+        getBrandPercentMultiplier(args)?.let { return it }
+
+        // Without a brand, the booking class alone is ambiguous: TAP sells the same
+        // class across several brands at different rates.  Assume the Economy
+        // Plus/Classic rate, which covers most economy inventory; Comfort's 115% is
+        // only awarded when the brand confirms it.
+        return when (args.fareClass) {
+            "C", "D", "Z", "J" -> 150
+            "Y", "B", "M", "S", "H", "Q", "V", "W", "A", "K", "L", "U", "E", "T", "O" -> 100
+            else -> 0
         }
     }
 }

--- a/src/test/kotlin/com/cowtool/acsqd/sqm/SqmTest.kt
+++ b/src/test/kotlin/com/cowtool/acsqd/sqm/SqmTest.kt
@@ -1001,4 +1001,68 @@ internal class SqmTest {
             assertEquals(39, lqm)
         }
     }
+
+    private fun tpResult(fareClass: String, fareBasis: String?) =
+        getEarningResult(
+            operatingAirline = "TP",
+            marketingAirline = null,
+            origin = "LIS",
+            destination = "YYZ",
+            fareClass = fareClass,
+            fareBasis = fareBasis,
+            ticketNumber = "047",
+            eliteBonusMultiplier = 0,
+        )!!
+
+    @Test
+    fun `TP earns by brand code parsed from a fare basis`() {
+        // LIS-YYZ is 3562
+        assertEquals(5343, tpResult("C", "C15TOP0A").basePoints)
+        assertEquals(5343, tpResult("D", "D15EXE0A").basePoints)
+        assertEquals(3562, tpResult("Y", "Y15PLU0A").basePoints)
+        assertEquals(3562, tpResult("M", "M15CLC0A").basePoints)
+        assertEquals(1781, tpResult("H", "H15BSC0A").basePoints)
+        assertEquals(0, tpResult("V", "V15DSC0A").basePoints)
+    }
+
+    @Test
+    fun `TP earns by brand name entered directly`() {
+        assertEquals(5343, tpResult("C", "TOP EXECUTIVE").basePoints)
+        assertEquals(5343, tpResult("D", "EXECUTIVE").basePoints)
+        assertEquals(4096, tpResult("W", "TOP PRIME").basePoints)
+        assertEquals(4096, tpResult("S", "PRIME").basePoints)
+        assertEquals(3562, tpResult("O", "PLUS").basePoints)
+        assertEquals(3562, tpResult("M", "CLASSIC").basePoints)
+        assertEquals(1781, tpResult("H", "BASIC").basePoints)
+        assertEquals(0, tpResult("V", "DISCOUNT").basePoints)
+    }
+
+    @Test
+    fun `TP reads TOP PRIME as comfort rather than business`() {
+        assertEquals(4096, tpResult("W", "TOP PRIME").basePoints)
+        assertEquals(5343, tpResult("W", "TOP EXECUTIVE").basePoints)
+    }
+
+    @Test
+    fun `TP brand overrides the fare class default`() {
+        // K alone assumes Classic/Plus, but Basic and Discount drop it further
+        assertEquals(3562, tpResult("K", null).basePoints)
+        assertEquals(1781, tpResult("K", "BASIC").basePoints)
+        assertEquals(0, tpResult("K", "DISCOUNT").basePoints)
+    }
+
+    @Test
+    fun `TP falls back to fare class when the brand is absent or unrecognized`() {
+        assertEquals(5343, tpResult("J", null).basePoints)
+        assertEquals(5343, tpResult("J", "RANDOM").basePoints)
+        assertEquals(3562, tpResult("W", null).basePoints)
+        assertEquals(3562, tpResult("O", null).basePoints)
+    }
+
+    @Test
+    fun `TP earns nothing in classes absent from the table`() {
+        assertEquals(0, tpResult("G", null).basePoints)
+        assertEquals(0, tpResult("P", null).basePoints)
+        assertEquals(0, tpResult("N", null).basePoints)
+    }
 }


### PR DESCRIPTION
Air Canada's partner page now prices TAP by fare brand most of the eligible classes are ambiguous on their own.

TAP encodes it as a three-letter code within the fare basis (Y15CLC0A), and the segment input also lets a user name the brand directly (TP,ARN,LIS,O,PLUS), so both options are accepted. 

Top Prime and Top Executive earn the same as Prime and Executive and need no cases of their own, but Prime is matched first so that "TOP PRIME" is not read as business. 

Prime / Top Prime fare-basis codes are unknown. The brand names work (PRIME, TOP PRIME → 115%), but a real fare basis like W15???0A falls through to 100%. Someone with TAP fare data could fill in the two tokens.  https://www.flyertalk.com/forum/tap-air-portugal-miles-go/978883-determining-fare-class-tap.html was used as a source.

When no brand is given, fall back to the booking class and assume the Economy Plus/Classic rate, which covers most economy inventory. Comfort new 115% is only awarded when the brand confirms it, since defaulting W/S/K there would over-report ordinary economy.

G and P now earn 0%, down from 50%, since the new table doesn't list them.

Also drops the LIS/OPO/PXO/FNC domestic split, which the new table does not
distinguish.

Note this changes earning for existing brand-less queries: V/W/S/L/K/U/A go
from 50% to 100%, O/E/T from 0% to 100%, and G/P from 50% to 0%.